### PR TITLE
Create Google Sites content plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
-# Reincarne-Logic
+# Reincarne Logic Google Site Structure
+
+Plan each page around clearly defined sections that pair concise copy with supportive visuals. Use Google Sites "Layouts" (columns, grids) to maintain alignment between text and imagery.
+
+## Home Page
+
+### Hero Introduction
+- **Layout:** Two-column hero layout with a headline and CTA on the left, supporting illustration or team photo on the right.
+- **Heading/Subheading:** `Reincarne Logic` / `Reinventing intelligent automation for mindful teams`.
+- **Copy & Visuals:** Two short sentences that summarize the mission paired with a branded illustration or product render.
+
+### Highlights Overview
+- **Layout:** Three-column grid showcasing the top value propositions.
+- **Heading/Subheading:** `What We Deliver` / `Human-centered AI that amplifies insight, creativity, and trust`.
+- **Copy & Visuals:** Each column includes a brief bullet list (max 3 bullets) and a distinctive icon representing Insight, Creativity, and Trust.
+
+### Featured Testimonial
+- **Layout:** Single-column layout with centered text.
+- **Heading/Subheading:** `Trusted by Visionary Leaders` / `"Reincarne Logic helped us unlock scalable intelligence." – Client Name`.
+- **Copy & Visuals:** Keep testimonial under 40 words. Include a grayscale photo or logo of the client.
+
+## Solutions Page
+
+### Introduction
+- **Layout:** Two-column layout; left column outlines challenges, right column displays solution graphic.
+- **Heading/Subheading:** `Solutions Tailored to You` / `Adaptive frameworks built for sustainable impact`.
+- **Copy & Visuals:** Short paragraph plus bullet list of industries served. Pair with iconography reflecting adaptability.
+
+### Service Modules
+- **Layout:** Four-column grid using cards for each service.
+- **Heading/Subheading:** `Service Modules` / `Modular building blocks you can mix and match`.
+- **Copy & Visuals:** Each card holds a 15-word summary and a monochrome line icon.
+
+### Process Snapshot
+- **Layout:** Three-step horizontal process layout.
+- **Heading/Subheading:** `How It Works` / `Discover → Architect → Empower`.
+- **Copy & Visuals:** Each step features a brief description (<20 words) and a numbered badge or step icon.
+
+## Projects Page
+
+### Portfolio Introduction
+- **Layout:** Two-column layout with text on the left and a collage of project thumbnails on the right.
+- **Heading/Subheading:** `Selected Projects` / `Explorations in responsible intelligence`.
+- **Copy & Visuals:** Provide a 2-sentence overview and a mosaic of 3–4 project images.
+
+### Case Study Grid
+- **Layout:** Three-card grid with consistent heights.
+- **Heading/Subheading:** `Case Studies` / `Outcome-driven engagements across sectors`.
+- **Copy & Visuals:** Each card contains a 25-word summary, key metrics, and a relevant icon or logo.
+
+### Research Highlights
+- **Layout:** Two-column layout with alternating image/text blocks.
+- **Heading/Subheading:** `Research Highlights` / `Pushing the boundaries of mindful automation`.
+- **Copy & Visuals:** Provide short abstracts (2 sentences) paired with imagery of prototypes or data visualizations.
+
+## Insights Page
+
+### Thought Leadership Intro
+- **Layout:** Full-width layout with a hero image background.
+- **Heading/Subheading:** `Insights` / `Ideas shaping the future of regenerative intelligence`.
+- **Copy & Visuals:** One short paragraph accompanied by a soft overlay on a conceptual image.
+
+### Articles & Guides
+- **Layout:** Two-column grid of cards.
+- **Heading/Subheading:** `Articles & Guides` / `Field notes from Reincarne Logic experts`.
+- **Copy & Visuals:** Summaries limited to 30 words with author avatars or publication icons.
+
+### Media & Talks
+- **Layout:** Three-column layout featuring embedded videos or slide previews.
+- **Heading/Subheading:** `Media & Talks` / `Conversations at the intersection of AI and responsibility`.
+- **Copy & Visuals:** Each tile contains a 1-sentence description and a play or slide icon.
+
+## Contact Page
+
+### Connection Prompt
+- **Layout:** Two-column layout with contact form on the left and support details on the right.
+- **Heading/Subheading:** `Let’s Connect` / `We’ll respond within two business days`.
+- **Copy & Visuals:** Brief 2-sentence prompt, paired with an icon representing communication.
+
+### Engagement Options
+- **Layout:** Three-column grid for Consultation, Partnership, and Media inquiries.
+- **Heading/Subheading:** `Engagement Options` / `Choose the best path to collaborate`.
+- **Copy & Visuals:** Each column contains a short description and relevant iconography (calendar, handshake, microphone).
+
+### Social & Location
+- **Layout:** Two-column layout; left column lists social links, right column embeds a map or office illustration.
+- **Heading/Subheading:** `Stay Connected` / `Follow our journey in mindful innovation`.
+- **Copy & Visuals:** Provide concise bullet list of social handles with icons and a map snapshot or stylized location graphic.
+
+## Visual & Content Guidelines
+
+- Use Google Sites column and grid layouts to align copy and imagery; keep spacing consistent across pages.
+- Limit paragraphs to 2–3 sentences and accompany them with icons, product shots, or photography that reinforce the message.
+- Maintain a cohesive color palette and icon style across all sections for visual harmony.
+- Prioritize accessibility: descriptive alt text for all images, sufficient contrast, and clear hierarchy in headings.
+


### PR DESCRIPTION
## Summary
- replace the placeholder README with a structured Google Sites content plan for Reincarne Logic
- outline sections for Home, Solutions, Projects, Insights, and Contact pages with layout, heading, and visual guidance
- add global guidelines that stress concise copy, imagery pairing, consistent styling, and accessibility

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c8f322a8ac8322b971772fd181a134