### PR TITLE
Implement simple Flask think tank prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Reincarne-Logic
+
+This repository contains a small prototype for a "Think Tank" web application. The app lets users submit ideas for solving grand challenges and displays the submissions in a simple list.
+
+## Running the app
+
+The application requires Python and Flask. Install dependencies and start the server with:
+
+```bash
+pip install flask
+python app.py
+```
+
+Visit `http://localhost:5000` in your browser to interact with the Think Tank interface.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,35 @@
+from flask import Flask, request, render_template_string, redirect, url_for
+
+app = Flask(__name__)
+
+# In-memory storage of ideas
+ideas = []
+
+# HTML template
+HTML = """
+<!doctype html>
+<title>Think Tank</title>
+<h1>Grand Challenge Think Tank</h1>
+<form action="{{ url_for('add_idea') }}" method="post">
+    <textarea name="idea" rows="4" cols="50" placeholder="Share your idea..."></textarea><br>
+    <button type="submit">Submit Idea</button>
+</form>
+<h2>Submitted Ideas</h2>
+<ul>
+{% for i in ideas %}<li>{{ i }}</li>{% else %}<li>No ideas yet!</li>{% endfor %}
+</ul>
+"""
+
+@app.route('/')
+def index():
+    return render_template_string(HTML, ideas=ideas)
+
+@app.route('/add', methods=['POST'])
+def add_idea():
+    idea = request.form.get('idea', '').strip()
+    if idea:
+        ideas.append(idea)
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add a small Flask application for submitting and displaying ideas
- update README with instructions for running the prototype

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0bc8e8f48322a642163a63c4e20b