### PR TITLE
Add SwiftUI iOS game prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a small prototype for a "Think Tank" web application. The app lets users submit ideas for solving grand challenges and displays the submissions in a simple list.
 
-## Running the app
+## Running the web app
 
 The application requires Python and Flask. Install dependencies and start the server with:
 
@@ -12,3 +12,7 @@ python app.py
 ```
 
 Visit `http://localhost:5000` in your browser to interact with the Think Tank interface.
+
+## iOS game prototype
+
+A SwiftUI prototype that turns the pattern-recognition prompt into a game lives in `ios/ReincarneLogicGame`. See `ios/README.md` for the gameplay loop and Xcode setup steps.

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,18 @@
+# Reincarne Logic iOS Game Prototype
+
+This SwiftUI prototype turns the pattern-recognition prompt into a fast-paced iOS game. Players watch a sequence of symbols, then recreate it quickly to earn a velocity bonus and stack meanings.
+
+## Running in Xcode
+
+1. Open Xcode and create a new **App** project named `ReincarneLogicGame`.
+2. Replace the generated Swift files with the contents of:
+   - `ReincarneLogicGameApp.swift`
+   - `ContentView.swift`
+   - `GameEngine.swift`
+3. Run on an iOS simulator (iOS 16+ recommended).
+
+## Gameplay
+
+- **Watch the sequence**: the game flashes a short pattern of symbols.
+- **Repeat fast**: tap the symbols in the same order to build your meaning stack.
+- **Earn velocity**: faster completions grant bonus points.

--- a/ios/README.md
+++ b/ios/README.md
@@ -4,12 +4,11 @@ This SwiftUI prototype turns the pattern-recognition prompt into a fast-paced iO
 
 ## Running in Xcode
 
-1. Open Xcode and create a new **App** project named `ReincarneLogicGame`.
-2. Replace the generated Swift files with the contents of:
-   - `ReincarneLogicGameApp.swift`
-   - `ContentView.swift`
-   - `GameEngine.swift`
-3. Run on an iOS simulator (iOS 16+ recommended).
+1. Open `ios/ReincarneLogicGame/ReincarneLogicGame.xcodeproj` in Xcode.
+2. Select an iOS simulator (iOS 16+ recommended).
+3. Build and run.
+
+If you want to adjust the bundle identifier or team, edit the target settings in Xcode.
 
 ## Gameplay
 

--- a/ios/ReincarneLogicGame/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/ReincarneLogicGame/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,53 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/ReincarneLogicGame/Assets.xcassets/Contents.json
+++ b/ios/ReincarneLogicGame/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/ReincarneLogicGame/ContentView.swift
+++ b/ios/ReincarneLogicGame/ContentView.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var engine = GameEngine()
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 16),
+        GridItem(.flexible(), spacing: 16),
+        GridItem(.flexible(), spacing: 16)
+    ]
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [Color.black, Color.blue.opacity(0.4)], startPoint: .top, endPoint: .bottom)
+                .ignoresSafeArea()
+            VStack(spacing: 20) {
+                VStack(spacing: 8) {
+                    Text("Pattern Velocity")
+                        .font(.largeTitle.bold())
+                        .foregroundColor(.white)
+                    Text("Stack meaning, recognize patterns, move fast.")
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.8))
+                }
+
+                HStack(spacing: 24) {
+                    statCard(title: "Score", value: "\(engine.score)")
+                    statCard(title: "Level", value: "\(engine.level)")
+                    statCard(title: "Time", value: String(format: "%.1f", engine.timeRemaining))
+                }
+
+                Text(engine.statusMessage)
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+
+                Group {
+                    if engine.phase == .showing, let tile = engine.showTile {
+                        VStack(spacing: 12) {
+                            Text(tile.symbol)
+                                .font(.system(size: 72))
+                            Text(tile.meaning.uppercased())
+                                .font(.headline)
+                                .foregroundColor(.white.opacity(0.8))
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.white.opacity(0.1))
+                        .cornerRadius(20)
+                    } else {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Meaning Stack")
+                                .font(.headline)
+                                .foregroundColor(.white)
+                            if engine.input.isEmpty {
+                                Text("Match the pattern to build your stack.")
+                                    .foregroundColor(.white.opacity(0.7))
+                            } else {
+                                ForEach(engine.input) { tile in
+                                    Text("• \(tile.meaning)")
+                                        .foregroundColor(.white.opacity(0.8))
+                                }
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                        .background(Color.white.opacity(0.1))
+                        .cornerRadius(20)
+                    }
+                }
+
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(engine.tiles) { tile in
+                        Button {
+                            engine.handleTap(tile: tile)
+                        } label: {
+                            VStack(spacing: 6) {
+                                Text(tile.symbol)
+                                    .font(.system(size: 36))
+                                Text(tile.meaning)
+                                    .font(.caption.bold())
+                            }
+                            .frame(maxWidth: .infinity, minHeight: 80)
+                            .padding(8)
+                            .background(Color.white.opacity(0.15))
+                            .foregroundColor(.white)
+                            .cornerRadius(16)
+                        }
+                        .disabled(engine.phase != .input)
+                    }
+                }
+
+                Button(action: primaryAction) {
+                    Text(primaryActionTitle)
+                        .font(.headline)
+                        .foregroundColor(.black)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.white)
+                        .cornerRadius(16)
+                }
+            }
+            .padding()
+        }
+    }
+
+    private func statCard(title: String, value: String) -> some View {
+        VStack(spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.white.opacity(0.7))
+            Text(value)
+                .font(.headline.bold())
+                .foregroundColor(.white)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(8)
+        .background(Color.white.opacity(0.12))
+        .cornerRadius(12)
+    }
+
+    private var primaryActionTitle: String {
+        switch engine.phase {
+        case .ready:
+            return "Start"
+        case .success:
+            return "Next Round"
+        case .failure:
+            return "Reset"
+        case .showing, .input:
+            return "Focus"
+        }
+    }
+
+    private func primaryAction() {
+        switch engine.phase {
+        case .ready:
+            engine.startGame()
+        case .success:
+            engine.nextRound()
+        case .failure:
+            engine.resetAfterFailure()
+        case .showing, .input:
+            break
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ios/ReincarneLogicGame/GameEngine.swift
+++ b/ios/ReincarneLogicGame/GameEngine.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+final class GameEngine: ObservableObject {
+    enum Phase {
+        case ready
+        case showing
+        case input
+        case success
+        case failure
+    }
+
+    struct Tile: Identifiable, Equatable {
+        let id = UUID()
+        let symbol: String
+        let meaning: String
+        let colorName: String
+    }
+
+    @Published private(set) var phase: Phase = .ready
+    @Published private(set) var sequence: [Tile] = []
+    @Published private(set) var input: [Tile] = []
+    @Published private(set) var showTile: Tile?
+    @Published private(set) var statusMessage = "Tap Start to begin."
+    @Published private(set) var score = 0
+    @Published private(set) var level = 1
+    @Published private(set) var timeRemaining: Double = 0
+
+    let tiles: [Tile] = [
+        Tile(symbol: "🔺", meaning: "Focus", colorName: "Red"),
+        Tile(symbol: "⚡", meaning: "Speed", colorName: "Yellow"),
+        Tile(symbol: "🌊", meaning: "Flow", colorName: "Blue"),
+        Tile(symbol: "🧠", meaning: "Meaning", colorName: "Purple"),
+        Tile(symbol: "🟢", meaning: "Growth", colorName: "Green"),
+        Tile(symbol: "✨", meaning: "Insight", colorName: "Mint")
+    ]
+
+    private var showTimer: Timer?
+    private var inputTimer: Timer?
+    private var showIndex = 0
+    private var inputStart: Date?
+
+    func startGame() {
+        score = 0
+        level = 1
+        nextRound()
+    }
+
+    func nextRound() {
+        input.removeAll()
+        sequence = generateSequence()
+        showIndex = 0
+        statusMessage = "Watch the pattern, then stack the meanings."
+        beginShowSequence()
+    }
+
+    func resetAfterFailure() {
+        score = 0
+        level = 1
+        input.removeAll()
+        sequence.removeAll()
+        showTile = nil
+        timeRemaining = 0
+        statusMessage = "Tap Start to try again."
+        phase = .ready
+    }
+
+    func handleTap(tile: Tile) {
+        guard phase == .input else { return }
+        if inputStart == nil {
+            inputStart = Date()
+        }
+        guard input.count < sequence.count else { return }
+        let expected = sequence[input.count]
+        if tile == expected {
+            input.append(tile)
+            if input.count == sequence.count {
+                finishRound(success: true)
+            }
+        } else {
+            finishRound(success: false)
+        }
+    }
+
+    private func generateSequence() -> [Tile] {
+        let length = min(2 + level, 6)
+        return (0..<length).map { _ in tiles.randomElement() ?? tiles[0] }
+    }
+
+    private func beginShowSequence() {
+        invalidateTimers()
+        phase = .showing
+        showTile = nil
+        showIndex = 0
+        showTimer = Timer.scheduledTimer(withTimeInterval: 0.85, repeats: true) { [weak self] timer in
+            guard let self else {
+                timer.invalidate()
+                return
+            }
+            if self.showIndex < self.sequence.count {
+                self.showTile = self.sequence[self.showIndex]
+                self.showIndex += 1
+            } else {
+                timer.invalidate()
+                self.showTile = nil
+                self.beginInputPhase()
+            }
+        }
+    }
+
+    private func beginInputPhase() {
+        phase = .input
+        inputStart = nil
+        timeRemaining = Double(sequence.count) * 3.5
+        statusMessage = "Repeat the pattern fast to earn velocity bonus."
+        inputTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] timer in
+            guard let self else {
+                timer.invalidate()
+                return
+            }
+            self.timeRemaining = max(0, self.timeRemaining - 0.1)
+            if self.timeRemaining <= 0 {
+                timer.invalidate()
+                self.finishRound(success: false)
+            }
+        }
+    }
+
+    private func finishRound(success: Bool) {
+        invalidateTimers()
+        if success {
+            let timeLimit = Double(sequence.count) * 3.5
+            let elapsed = Date().timeIntervalSince(inputStart ?? Date())
+            let velocityBonus = max(0, Int((timeLimit - elapsed) * 10))
+            score += (sequence.count * 10) + velocityBonus
+            level += 1
+            statusMessage = "Great stack! +\(velocityBonus) velocity bonus."
+            phase = .success
+        } else {
+            statusMessage = "Pattern break. Reset and try again."
+            phase = .failure
+        }
+    }
+
+    private func invalidateTimers() {
+        showTimer?.invalidate()
+        inputTimer?.invalidate()
+        showTimer = nil
+        inputTimer = nil
+    }
+}

--- a/ios/ReincarneLogicGame/Info.plist
+++ b/ios/ReincarneLogicGame/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleDisplayName</key>
+    <string>Reincarne Logic</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>armv7</string>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+</dict>
+</plist>

--- a/ios/ReincarneLogicGame/ReincarneLogicGame.xcodeproj/project.pbxproj
+++ b/ios/ReincarneLogicGame/ReincarneLogicGame.xcodeproj/project.pbxproj
@@ -1,0 +1,238 @@
+// !$*UTF8*$!
+{
+    archiveVersion = 1;
+    classes = {
+    };
+    objectVersion = 56;
+    objects = {
+
+/* Begin PBXBuildFile section */
+        111111111111111111111111 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222222222222222222222222 /* ContentView.swift */; };
+        111111111111111111111112 /* GameEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222222222222222222222223 /* GameEngine.swift */; };
+        111111111111111111111113 /* ReincarneLogicGameApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222222222222222222222224 /* ReincarneLogicGameApp.swift */; };
+        111111111111111111111114 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 222222222222222222222225 /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+        222222222222222222222220 /* ReincarneLogicGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = ReincarneLogicGame.app; sourceTree = BUILT_PRODUCTS_DIR; };
+        222222222222222222222221 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+        222222222222222222222222 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+        222222222222222222222223 /* GameEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameEngine.swift; sourceTree = "<group>"; };
+        222222222222222222222224 /* ReincarneLogicGameApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReincarneLogicGameApp.swift; sourceTree = "<group>"; };
+        222222222222222222222225 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+        333333333333333333333333 /* Frameworks */ = {
+            isa = PBXFrameworksBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+        444444444444444444444444 /* ReincarneLogicGame */ = {
+            isa = PBXGroup;
+            children = (
+                222222222222222222222224 /* ReincarneLogicGameApp.swift */,
+                222222222222222222222222 /* ContentView.swift */,
+                222222222222222222222223 /* GameEngine.swift */,
+                222222222222222222222225 /* Assets.xcassets */,
+                222222222222222222222221 /* Info.plist */,
+            );
+            path = ReincarneLogicGame;
+            sourceTree = "<group>";
+        };
+        444444444444444444444445 /* Products */ = {
+            isa = PBXGroup;
+            children = (
+                222222222222222222222220 /* ReincarneLogicGame.app */,
+            );
+            name = Products;
+            sourceTree = "<group>";
+        };
+        444444444444444444444446 /* Root */ = {
+            isa = PBXGroup;
+            children = (
+                444444444444444444444444 /* ReincarneLogicGame */,
+                444444444444444444444445 /* Products */,
+            );
+            sourceTree = "<group>";
+        };
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+        555555555555555555555555 /* ReincarneLogicGame */ = {
+            isa = PBXNativeTarget;
+            buildConfigurationList = 666666666666666666666666 /* Build configuration list for PBXNativeTarget "ReincarneLogicGame" */;
+            buildPhases = (
+                333333333333333333333334 /* Sources */,
+                333333333333333333333333 /* Frameworks */,
+                333333333333333333333335 /* Resources */,
+            );
+            buildRules = (
+            );
+            dependencies = (
+            );
+            name = ReincarneLogicGame;
+            productName = ReincarneLogicGame;
+            productReference = 222222222222222222222220 /* ReincarneLogicGame.app */;
+            productType = "com.apple.product-type.application";
+        };
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+        777777777777777777777777 /* Project object */ = {
+            isa = PBXProject;
+            attributes = {
+                BuildIndependentTargetsInParallel = 1;
+                LastSwiftUpdateCheck = 1500;
+                LastUpgradeCheck = 1500;
+                TargetAttributes = {
+                    555555555555555555555555 = {
+                        CreatedOnToolsVersion = 15.0;
+                    };
+                };
+            };
+            buildConfigurationList = 666666666666666666666667 /* Build configuration list for PBXProject "ReincarneLogicGame" */;
+            compatibilityVersion = "Xcode 15.0";
+            developmentRegion = en;
+            hasScannedForEncodings = 0;
+            knownRegions = (
+                en,
+                Base,
+            );
+            mainGroup = 444444444444444444444446 /* Root */;
+            productRefGroup = 444444444444444444444445 /* Products */;
+            projectDirPath = "";
+            projectRoot = "";
+            targets = (
+                555555555555555555555555 /* ReincarneLogicGame */,
+            );
+        };
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+        333333333333333333333335 /* Resources */ = {
+            isa = PBXResourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                111111111111111111111114 /* Assets.xcassets in Resources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+        333333333333333333333334 /* Sources */ = {
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                111111111111111111111113 /* ReincarneLogicGameApp.swift in Sources */,
+                111111111111111111111111 /* ContentView.swift in Sources */,
+                111111111111111111111112 /* GameEngine.swift in Sources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+        888888888888888888888881 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                CLANG_ENABLE_MODULES = YES;
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                DEVELOPMENT_TEAM = "";
+                INFOPLIST_FILE = ReincarneLogicGame/Info.plist;
+                IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@executable_path/Frameworks",
+                );
+                PRODUCT_BUNDLE_IDENTIFIER = "com.reincarnelogic.game";
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = 1;
+            };
+            name = Debug;
+        };
+        888888888888888888888882 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                CLANG_ENABLE_MODULES = YES;
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                DEVELOPMENT_TEAM = "";
+                INFOPLIST_FILE = ReincarneLogicGame/Info.plist;
+                IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@executable_path/Frameworks",
+                );
+                PRODUCT_BUNDLE_IDENTIFIER = "com.reincarnelogic.game";
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = 1;
+            };
+            name = Release;
+        };
+        888888888888888888888883 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                CLANG_ENABLE_MODULES = YES;
+                CODE_SIGN_STYLE = Automatic;
+                DEVELOPMENT_TEAM = "";
+                ENABLE_PREVIEWS = YES;
+                INFOPLIST_FILE = ReincarneLogicGame/Info.plist;
+                IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+                PRODUCT_BUNDLE_IDENTIFIER = "com.reincarnelogic.game";
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_VERSION = 5.0;
+            };
+            name = Debug;
+        };
+        888888888888888888888884 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                CLANG_ENABLE_MODULES = YES;
+                CODE_SIGN_STYLE = Automatic;
+                DEVELOPMENT_TEAM = "";
+                ENABLE_PREVIEWS = YES;
+                INFOPLIST_FILE = ReincarneLogicGame/Info.plist;
+                IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+                PRODUCT_BUNDLE_IDENTIFIER = "com.reincarnelogic.game";
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_VERSION = 5.0;
+            };
+            name = Release;
+        };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+        666666666666666666666666 /* Build configuration list for PBXNativeTarget "ReincarneLogicGame" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                888888888888888888888881 /* Debug */,
+                888888888888888888888882 /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+        666666666666666666666667 /* Build configuration list for PBXProject "ReincarneLogicGame" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                888888888888888888888883 /* Debug */,
+                888888888888888888888884 /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+/* End XCConfigurationList section */
+    };
+    rootObject = 777777777777777777777777 /* Project object */;
+}

--- a/ios/ReincarneLogicGame/ReincarneLogicGameApp.swift
+++ b/ios/ReincarneLogicGame/ReincarneLogicGameApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct ReincarneLogicGameApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an iOS SwiftUI prototype that transforms the pattern-recognition concept into a playable game. 
- Ship a self-contained gameplay engine and UI so the prototype can be opened and iterated in Xcode. 
- Keep the web app intact while adding platform-specific demo code under `ios/ReincarneLogicGame`.

### Description
- Add a SwiftUI app entry `ReincarneLogicGameApp.swift` and main UI in `ContentView.swift` implementing the game layout and controls. 
- Implement game logic in `GameEngine.swift` including sequence generation, show/input phases, timers, scoring, velocity bonus, and state management. 
- Add `ios/README.md` with Xcode setup and gameplay instructions and update the root `README.md` to reference the iOS prototype. 
- Files added: `ios/ReincarneLogicGame/{ReincarneLogicGameApp.swift,ContentView.swift,GameEngine.swift}` and `ios/README.md`.

### Testing
- No automated tests were run against these changes. 
- The changes were committed as prototype scaffolding intended to be opened and run in Xcode (manual build/run required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483fd2f084832299897b009cacd280)