### PR TITLE
Add the Afro-Gorgon Serpentine Sense vertical slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.DS_Store
+DerivedData/
+xcuserdata/

--- a/README.md
+++ b/README.md
@@ -16,3 +16,23 @@ Visit `http://localhost:5000` in your browser to interact with the Think Tank in
 ## iOS game prototype
 
 A SwiftUI prototype that turns the pattern-recognition prompt into a game lives in `ios/ReincarneLogicGame`. See `ios/README.md` for the gameplay loop and Xcode setup steps.
+
+## Serpentine Sense experiment
+
+The iOS prototype now includes **Serpentine Sense**, an Afro-Gorgon
+environmental-awareness vertical slice. It fuses serpentine instinct, aura
+perception, aetherware prediction, and hex sensitivity into an eight-direction
+threat-reading loop with calculated time dilation.
+
+- Open the **Serpentine** tab in the iOS app to play the cognition loop.
+- Read [the system RFC](docs/SERPENTINE_SENSE_RFC.md) for lore, human-factors
+  assumptions, architecture, accessibility, and Unreal-port guidance.
+- Run the deterministic balance model with:
+
+  ```bash
+  python3 simulation/serpentine_sense_balance.py
+  python3 -m unittest discover -s simulation -p "test_*.py"
+  ```
+
+The simulator uses only the Python standard library.
+

--- a/docs/SERPENTINE_SENSE_RFC.md
+++ b/docs/SERPENTINE_SENSE_RFC.md
@@ -1,0 +1,304 @@
+# RFC: Serpentine Sense — Aethercoil Awareness System
+
+Status: experimental vertical slice  
+Target: Reincarne Logic iOS prototype first; engine-agnostic core afterward  
+Working name: **Serpentine Sense**  
+Subsystem codename: **Aethercoil**
+
+## 1. Intent
+
+Serpentine Sense is an environmental-awareness superpower for Afro-Gorgon,
+cybernetic, magical-energy-wielding entities. It is inspired by the design
+problem solved by "danger sense" mechanics, but it is not a renamed spider
+ability.
+
+The fantasy is not merely "danger is near." A Gorgon experiences the world as
+overlapping pressure fields: muscle intent, aura turbulence, spell causality,
+machine prediction, ancestral resonance, and the mineral memory of structures.
+The player should feel a living crown of serpents thinking around them while
+their aetherware turns instinct into a short, actionable glimpse of what may
+happen next.
+
+The system must:
+
+- warn without becoming an omniscient autopilot;
+- create choices instead of one prescribed QTE button;
+- work on systemic threats, not only authored set pieces;
+- preserve a distinct Gorgon identity built around coils, gaze, thresholds,
+  aura, stone, and distributed perception;
+- combine biological, magical, and cybernetic sensing without treating them as
+  interchangeable skins;
+- remain accessible when audio, haptics, motion, or color cannot be used.
+
+"Afro-Gorgon" is treated here as an original Afrofuturist identity, not a
+generic collage of African cultures. Production art and narrative should name
+the character's specific lineage, region, community, and visual references
+before incorporating real-world sacred or ceremonial symbols.
+
+## 2. Human factors baseline
+
+Simple reaction time and choice reaction time are different design budgets.
+A player can react quickly to one expected cue, but identifying a threat,
+choosing a response, aiming, and executing it is a choice task. The mechanic
+therefore uses multimodal cues for fast orientation and controlled time dilation
+for deliberation.
+
+Do not treat any single reaction-time number as universal. Display latency,
+input hardware, age, ability, fatigue, cue compatibility, and the number of
+choices all change the result. A comparative laboratory study found auditory
+responses faster than visual responses in its task, while the Deary-Liewald
+work provides a reproducible distinction between simple and four-choice
+reaction tasks:
+
+- [Comparative visual and auditory reaction-time study](https://pmc.ncbi.nlm.nih.gov/articles/PMC4456887/)
+- [The Deary-Liewald reaction-time task](https://pubmed.ncbi.nlm.nih.gov/21287123/)
+
+Apple's Core Haptics supports coordinated haptic and audio events, making it a
+good fit for the iOS vertical slice:
+
+- [Core Haptics documentation](https://developer.apple.com/documentation/corehaptics)
+- [Expanding the Sensory Experience with Core Haptics](https://developer.apple.com/videos/play/wwdc2019/223/)
+
+Initial tuning targets are hypotheses to test, not biological laws:
+
+| Budget | Starting target |
+|---|---:|
+| Cue recognition | 170 ms |
+| Input/motor allowance | 80 ms |
+| Usable choice window | 900 ms |
+| Minimum world time scale | 0.10× |
+| Maximum assisted real-time window | 2.25 s |
+
+## 3. Power identity: four sensing channels
+
+Each channel contributes a different kind of evidence. Threats may activate
+more than one channel, but one channel normally dominates the cue.
+
+| Channel | Origin | What it perceives | Player cue language |
+|---|---|---|---|
+| **Coil Instinct** | Serpentine biology | Motion, pressure, breath, muscle intent | Tight directional haptic snap |
+| **Aura Sight** | Personal magical field | Hostility, fear, life-force distortion | Colored corona plus heartbeat bloom |
+| **Aetherware Oracle** | Cybernetic prediction | Trajectories, networks, machine behavior | Braided circuit line and precise tone |
+| **Hex Echo** | Sorcery/causal sensitivity | Curses, delayed spells, broken oaths | Reversed chime and glyph fracture |
+
+These channels create useful disagreement. Aetherware may predict that a beam
+will miss while Aura Sight senses the attacker's intent to redirect it. Hex Echo
+may detect a curse that has no physical trajectory. Coil Instinct may be the
+only channel still trustworthy inside an anti-magic field.
+
+## 4. Threat families and response verbs
+
+The prototype uses five threat families and five response verbs. The full game
+should allow several valid responses based on build, position, allies, and
+available energy.
+
+| Threat family | Example | Strong default response |
+|---|---|---|
+| Kinetic fracture | Debris, projectile, collapsing floor | **Flow** — evade or redirect momentum |
+| Aura predation | Hostile will, possession, panic cascade | **Gaze** — expose and lock hostile intent |
+| Hex weave | Curse, delayed ritual, probability snare | **Sever** — cut the causal strand |
+| Aether surge | Unstable magic, portal shear, overload | **Ward** — ground or absorb the field |
+| Cyber intrusion | Drone swarm, implant spoof, hostile mesh | **Rewrite** — counter-command the system |
+
+The verbs are deliberately broader than "dodge." That keeps the system from
+collapsing into a reskinned QTE.
+
+## 5. Interaction loop
+
+1. **Whisper** — one or more channels notice an anomaly. The player receives a
+   subtle directional cue but combat does not slow yet.
+2. **Constriction** — confidence and severity cross the assistance threshold.
+   A synchronized haptic/audio cue declares direction and channel.
+3. **Crown Flare** — Aethercoil computes only as much time dilation as the
+   current lead time and player accessibility profile require.
+4. **Orient** — the player selects the source direction. Camera assistance may
+   bias toward it, but never forces a snap during manual aiming.
+5. **Channel** — the player chooses Flow, Gaze, Sever, Ward, Rewrite, or a
+   character-specific ability.
+6. **Afterimage** — world time returns quickly, the resolution executes, and
+   Aethercoil reserve/strain updates.
+
+Ignoring the cue remains a valid decision. A player may accept damage to finish
+a boss phase, preserve reserve for a civilian rescue, or trust an ally to
+respond.
+
+## 6. Balance model
+
+Let:
+
+- `L` be predicted lead time in world seconds;
+- `B` be the requested usable decision budget in real seconds;
+- `C` be cue-recognition latency in real seconds;
+- `I` be input/motor allowance in real seconds;
+- `s` be world time scale, where `1.0` is normal time and `0.1` is 10% speed.
+
+The requested scale is:
+
+```text
+s_requested = clamp(L / (B + C + I), s_min, 1)
+```
+
+The real time available before impact is `L / s`. The usable response window is:
+
+```text
+usable_real_seconds = (L / s) - C - I
+```
+
+Time dilation must not fully trust a weak forecast. Let `q` be forecast
+confidence, `v` be severity, and `w` be a smooth confidence weight between the
+minimum and full-confidence thresholds:
+
+```text
+assist_weight = smoothstep(q_min, q_full, q) * v
+s_effective = 1 - (1 - s_requested) * assist_weight
+```
+
+This blends uncertain or trivial events toward normal time. It prevents a noisy
+sensor from repeatedly freezing the game.
+
+Aethercoil reserve limits assistance:
+
+```text
+reserve_cost = k * (1 - s_effective) * (L / s_effective) * (0.5 + 0.5v)
+```
+
+If the player lacks reserve, assistance is proportionally reduced rather than
+silently granted. Reserve regenerates only outside Crown Flare. Severe failures
+can add **Crown Static**, temporarily lowering confidence and creating a real
+risk/reward arc.
+
+### Recommended starting bands
+
+| Situation | Lead time | Confidence | Expected behavior |
+|---|---:|---:|---|
+| Readable projectile | 1.2–2.0 s | 0.85–1.0 | Little or no dilation |
+| Chaotic debris | 0.45–1.0 s | 0.65–0.9 | Moderate dilation |
+| Point-blank strike | 0.15–0.4 s | 0.9–1.0 | Heavy dilation, high reserve cost |
+| Ambiguous omen | Any | <0.45 | Whisper only; no forced slowdown |
+
+If even `s_min` cannot create the accessibility target, the event is
+mechanically unavoidable. Designers must then either provide an earlier
+forecast, allow an expensive automatic defense, or label the event as damage
+pressure rather than a reaction challenge.
+
+## 7. System architecture
+
+```mermaid
+flowchart TD
+    A["Threat producers"] --> B["Channel adapters"]
+    B --> C["Aethercoil fusion"]
+    C --> D["Response budgeter"]
+    D --> E["Multimodal cue"]
+    E --> F["Player response"]
+    F --> G["World resolution + telemetry"]
+```
+
+### Threat producers
+
+- Physics predicts trajectories and structural intersections.
+- Combat AI exposes intent windows, not private final decisions.
+- Spell systems publish cast, delayed-effect, curse, and causal-chain events.
+- Aura systems publish hostility and field-distortion gradients.
+- Network/cyber systems publish intrusion and command-conflict events.
+
+### Channel adapters
+
+Every producer emits a common `ThreatSignature`:
+
+```text
+id, family, source, target, direction, lead_time,
+severity, confidence, ambiguity, dominant_channel,
+valid_responses, accessibility_priority
+```
+
+### Fusion
+
+Fusion deduplicates events, combines independent evidence, and preserves
+disagreement. It should be deterministic first. Physical trajectories belong
+on CPU physics tasks or general GPU compute when scale demands it; Tensor Cores
+are relevant only if a trained inference model is actually part of the design.
+
+### Scheduling
+
+- High-confidence imminent threats update every simulation tick.
+- Distant/low-severity threats update at a reduced cadence.
+- Prediction runs against immutable snapshots to avoid racing live world state.
+- Results carry a source-frame/version identifier and are discarded when stale.
+- A fixed per-frame budget prevents awareness work from stealing the render
+  frame.
+
+## 8. Prototype behavior
+
+The iOS vertical slice simulates this loop:
+
+- a threat appears in one of eight directions;
+- the engine evaluates lead time, severity, confidence, and ambiguity;
+- world countdown advances at the computed time scale;
+- the interface fires a directional stereo cue plus haptic pulse;
+- the player identifies direction and selects a response verb;
+- correct choices build score and Coil Streak;
+- time dilation consumes Aethercoil reserve;
+- low-confidence threats receive weaker assistance.
+
+The Python simulator mirrors the same equations so tuning can happen without
+launching Xcode.
+
+```bash
+python3 simulation/serpentine_sense_balance.py
+python3 -m unittest simulation/test_serpentine_sense_balance.py
+```
+
+## 9. Accessibility contract
+
+- Never encode direction or threat family by color alone.
+- Provide independent visual, audio, and haptic cue toggles.
+- Offer a configurable target decision window and minimum time scale.
+- Support reduced motion; camera assistance cannot require rapid camera motion.
+- Allow hold, toggle, and auto-orient control modes.
+- Expose cue intensity without tying mechanical difficulty to physical output
+  strength.
+- Record timing telemetry only with consent and avoid inferring medical or
+  cognitive conditions from player performance.
+
+## 10. Telemetry for tuning
+
+Collect aggregate, privacy-respecting events:
+
+- prediction lead time and confidence;
+- time scale and reserve cost;
+- cue-to-orient time;
+- orient-to-response time;
+- chosen response and valid response set;
+- success, ignore, late response, or wrong interpretation;
+- number of overlapping threats;
+- accessibility preset, only when the player opts into telemetry.
+
+The core balance question is not "did the player press fast enough?" It is:
+"did the cue give the player enough information and time to make an intentional
+Gorgon decision?"
+
+## 11. Acceptance criteria for the skeleton
+
+- Serpentine Sense is reachable as its own tab in the existing iOS prototype.
+- Threats originate from eight directions and five distinct families.
+- Direction and response are separate choices.
+- Time scale is derived from lead time, player budget, confidence, severity,
+  and available reserve.
+- A low-confidence event cannot trigger maximum slowdown.
+- The same balance invariants are covered by deterministic Python tests.
+- The design remains functional with any one cue modality disabled.
+- No code claims to use ML-specific hardware when it is performing ordinary
+  physics or deterministic scoring.
+
+## 12. Next-stage expansion
+
+1. Add real Core Haptics patterns per channel rather than generic impact
+   generators.
+2. Calibrate stereo/spatial cues on device and measure end-to-end latency.
+3. Add overlapping threats and let the player braid responses into one action.
+4. Port `ThreatSignature` and the budgeter into an Unreal subsystem with
+   Gameplay Tags, Mass/async task producers, and deterministic replay tests.
+5. Give individual Afro-Gorgon lineages different channel weights and response
+   vocabularies after their cultural and narrative foundations are defined.
+6. Prototype Crown Static, false omens, ally warnings, and voluntary cue ignore.
+

--- a/ios/README.md
+++ b/ios/README.md
@@ -15,3 +15,21 @@ If you want to adjust the bundle identifier or team, edit the target settings in
 - **Watch the sequence**: the game flashes a short pattern of symbols.
 - **Repeat fast**: tap the symbols in the same order to build your meaning stack.
 - **Earn velocity**: faster completions grant bonus points.
+
+## Serpentine Sense mode
+
+The **Serpentine** tab adds a second cognition game built for an original
+Afro-Gorgon/Aethercoil power fantasy.
+
+1. Wake the crown and receive a visual, stereo-audio, and haptic omen.
+2. Read which of eight directions contains the threat.
+3. Identify the threat family through its dominant channel: Coil Instinct, Aura
+   Sight, Aetherware Oracle, or Hex Echo.
+4. Select Flow, Gaze, Sever, Ward, or Rewrite before the threat crosses the
+   threshold.
+5. Manage Aethercoil reserve; stronger time dilation consumes more energy.
+
+The prototype targets iOS 16+. Audio and haptics can be toggled independently,
+direction is never encoded by color alone, and the full balance model is
+documented in [the Serpentine Sense RFC](../docs/SERPENTINE_SENSE_RFC.md).
+

--- a/ios/ReincarneLogicGame/ContentView.swift
+++ b/ios/ReincarneLogicGame/ContentView.swift
@@ -1,6 +1,23 @@
 import SwiftUI
 
 struct ContentView: View {
+    var body: some View {
+        TabView {
+            PatternVelocityView()
+                .tabItem {
+                    Label("Pattern", systemImage: "square.grid.3x3.fill")
+                }
+
+            SerpentineSenseView()
+                .tabItem {
+                    Label("Serpentine", systemImage: "eye.circle.fill")
+                }
+        }
+        .tint(Color(red: 0.96, green: 0.73, blue: 0.25))
+    }
+}
+
+private struct PatternVelocityView: View {
     @StateObject private var engine = GameEngine()
 
     private let columns = [
@@ -11,8 +28,12 @@ struct ContentView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(colors: [Color.black, Color.blue.opacity(0.4)], startPoint: .top, endPoint: .bottom)
-                .ignoresSafeArea()
+            LinearGradient(
+                colors: [Color.black, Color.blue.opacity(0.4)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
             VStack(spacing: 20) {
                 VStack(spacing: 8) {
                     Text("Pattern Velocity")
@@ -26,7 +47,10 @@ struct ContentView: View {
                 HStack(spacing: 24) {
                     statCard(title: "Score", value: "\(engine.score)")
                     statCard(title: "Level", value: "\(engine.level)")
-                    statCard(title: "Time", value: String(format: "%.1f", engine.timeRemaining))
+                    statCard(
+                        title: "Time",
+                        value: String(format: "%.1f", engine.timeRemaining)
+                    )
                 }
 
                 Text(engine.statusMessage)
@@ -150,3 +174,4 @@ struct ContentView: View {
 #Preview {
     ContentView()
 }
+

--- a/ios/ReincarneLogicGame/GameEngine.swift
+++ b/ios/ReincarneLogicGame/GameEngine.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 final class GameEngine: ObservableObject {
@@ -148,3 +149,4 @@ final class GameEngine: ObservableObject {
         inputTimer = nil
     }
 }
+

--- a/ios/ReincarneLogicGame/ReincarneLogicGame.xcodeproj/project.pbxproj
+++ b/ios/ReincarneLogicGame/ReincarneLogicGame.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
         111111111111111111111111 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222222222222222222222222 /* ContentView.swift */; };
         111111111111111111111112 /* GameEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222222222222222222222223 /* GameEngine.swift */; };
+        111111111111111111111115 /* SerpentineSenseEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222222222222222222222226 /* SerpentineSenseEngine.swift */; };
+        111111111111111111111116 /* SerpentineSenseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222222222222222222222227 /* SerpentineSenseView.swift */; };
         111111111111111111111113 /* ReincarneLogicGameApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222222222222222222222224 /* ReincarneLogicGameApp.swift */; };
         111111111111111111111114 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 222222222222222222222225 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
@@ -18,6 +20,8 @@
         222222222222222222222221 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
         222222222222222222222222 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
         222222222222222222222223 /* GameEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameEngine.swift; sourceTree = "<group>"; };
+        222222222222222222222226 /* SerpentineSenseEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerpentineSenseEngine.swift; sourceTree = "<group>"; };
+        222222222222222222222227 /* SerpentineSenseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerpentineSenseView.swift; sourceTree = "<group>"; };
         222222222222222222222224 /* ReincarneLogicGameApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReincarneLogicGameApp.swift; sourceTree = "<group>"; };
         222222222222222222222225 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -39,6 +43,8 @@
                 222222222222222222222224 /* ReincarneLogicGameApp.swift */,
                 222222222222222222222222 /* ContentView.swift */,
                 222222222222222222222223 /* GameEngine.swift */,
+                222222222222222222222226 /* SerpentineSenseEngine.swift */,
+                222222222222222222222227 /* SerpentineSenseView.swift */,
                 222222222222222222222225 /* Assets.xcassets */,
                 222222222222222222222221 /* Info.plist */,
             );
@@ -133,6 +139,8 @@
                 111111111111111111111113 /* ReincarneLogicGameApp.swift in Sources */,
                 111111111111111111111111 /* ContentView.swift in Sources */,
                 111111111111111111111112 /* GameEngine.swift in Sources */,
+                111111111111111111111115 /* SerpentineSenseEngine.swift in Sources */,
+                111111111111111111111116 /* SerpentineSenseView.swift in Sources */,
             );
             runOnlyForDeploymentPostprocessing = 0;
         };
@@ -236,3 +244,4 @@
     };
     rootObject = 777777777777777777777777 /* Project object */;
 }
+

--- a/ios/ReincarneLogicGame/SerpentineSenseEngine.swift
+++ b/ios/ReincarneLogicGame/SerpentineSenseEngine.swift
@@ -1,0 +1,596 @@
+import Combine
+import Foundation
+
+enum SenseChannel: String, CaseIterable, Identifiable {
+    case coilInstinct
+    case auraSight
+    case aetherwareOracle
+    case hexEcho
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .coilInstinct: return "Coil Instinct"
+        case .auraSight: return "Aura Sight"
+        case .aetherwareOracle: return "Aetherware Oracle"
+        case .hexEcho: return "Hex Echo"
+        }
+    }
+
+    var glyph: String {
+        switch self {
+        case .coilInstinct: return "〰"
+        case .auraSight: return "◉"
+        case .aetherwareOracle: return "⌬"
+        case .hexEcho: return "⌁"
+        }
+    }
+
+    var toneFrequency: Double {
+        switch self {
+        case .coilInstinct: return 180
+        case .auraSight: return 260
+        case .aetherwareOracle: return 420
+        case .hexEcho: return 135
+        }
+    }
+}
+
+enum SerpentineResponse: String, CaseIterable, Identifiable {
+    case flow
+    case gaze
+    case sever
+    case ward
+    case rewrite
+
+    var id: String { rawValue }
+
+    var title: String { rawValue.capitalized }
+
+    var glyph: String {
+        switch self {
+        case .flow: return "≈"
+        case .gaze: return "◉"
+        case .sever: return "╱"
+        case .ward: return "⬡"
+        case .rewrite: return "⌘"
+        }
+    }
+
+    var instruction: String {
+        switch self {
+        case .flow: return "Redirect momentum"
+        case .gaze: return "Lock hostile intent"
+        case .sever: return "Cut the causal strand"
+        case .ward: return "Ground the aether field"
+        case .rewrite: return "Counter-command the mesh"
+        }
+    }
+}
+
+enum ThreatFamily: String, CaseIterable, Identifiable {
+    case kineticFracture
+    case auraPredation
+    case hexWeave
+    case aetherSurge
+    case cyberIntrusion
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .kineticFracture: return "Kinetic Fracture"
+        case .auraPredation: return "Aura Predation"
+        case .hexWeave: return "Hex Weave"
+        case .aetherSurge: return "Aether Surge"
+        case .cyberIntrusion: return "Cyber Intrusion"
+        }
+    }
+
+    var glyph: String {
+        switch self {
+        case .kineticFracture: return "◈"
+        case .auraPredation: return "◉"
+        case .hexWeave: return "⌁"
+        case .aetherSurge: return "✦"
+        case .cyberIntrusion: return "⌬"
+        }
+    }
+
+    var dominantChannel: SenseChannel {
+        switch self {
+        case .kineticFracture: return .coilInstinct
+        case .auraPredation: return .auraSight
+        case .hexWeave: return .hexEcho
+        case .aetherSurge: return .auraSight
+        case .cyberIntrusion: return .aetherwareOracle
+        }
+    }
+
+    var correctResponse: SerpentineResponse {
+        switch self {
+        case .kineticFracture: return .flow
+        case .auraPredation: return .gaze
+        case .hexWeave: return .sever
+        case .aetherSurge: return .ward
+        case .cyberIntrusion: return .rewrite
+        }
+    }
+}
+
+enum ThreatDirection: String, CaseIterable, Identifiable {
+    case north
+    case northEast
+    case east
+    case southEast
+    case south
+    case southWest
+    case west
+    case northWest
+
+    var id: String { rawValue }
+
+    var shortLabel: String {
+        switch self {
+        case .north: return "N"
+        case .northEast: return "NE"
+        case .east: return "E"
+        case .southEast: return "SE"
+        case .south: return "S"
+        case .southWest: return "SW"
+        case .west: return "W"
+        case .northWest: return "NW"
+        }
+    }
+
+    var spokenLabel: String {
+        switch self {
+        case .north: return "north"
+        case .northEast: return "northeast"
+        case .east: return "east"
+        case .southEast: return "southeast"
+        case .south: return "south"
+        case .southWest: return "southwest"
+        case .west: return "west"
+        case .northWest: return "northwest"
+        }
+    }
+
+    /// SwiftUI screen-space angle: north begins at -90 degrees.
+    var angleRadians: Double {
+        switch self {
+        case .north: return -.pi / 2
+        case .northEast: return -.pi / 4
+        case .east: return 0
+        case .southEast: return .pi / 4
+        case .south: return .pi / 2
+        case .southWest: return 3 * .pi / 4
+        case .west: return .pi
+        case .northWest: return -3 * .pi / 4
+        }
+    }
+
+    /// Constant-power stereo pan. Vertical cues remain centered.
+    var stereoPan: Double {
+        switch self {
+        case .east, .northEast, .southEast: return 0.82
+        case .west, .northWest, .southWest: return -0.82
+        case .north, .south: return 0
+        }
+    }
+}
+
+struct SerpentineThreat: Identifiable, Equatable {
+    let id = UUID()
+    let family: ThreatFamily
+    let direction: ThreatDirection
+    let leadSeconds: Double
+    let severity: Double
+    let confidence: Double
+    let ambiguity: Double
+
+    var channel: SenseChannel { family.dominantChannel }
+}
+
+struct SerpentineSenseTuning {
+    var targetDecisionSeconds = 0.90
+    var cueLatencySeconds = 0.17
+    var inputLatencySeconds = 0.08
+    var minimumTimeScale = 0.10
+    var minimumAssistConfidence = 0.45
+    var fullAssistConfidence = 0.85
+    var ambiguityBudgetMultiplier = 0.35
+    var ambiguityAssistPenalty = 0.35
+    var reserveCostRate = 7.5
+    var maximumReserve = 100.0
+}
+
+struct SerpentineSenseDecision: Equatable {
+    let requestedTimeScale: Double
+    let timeScale: Double
+    let realWindowSeconds: Double
+    let usableResponseSeconds: Double
+    let requestedDecisionSeconds: Double
+    let assistWeight: Double
+    let reserveCost: Double
+    let reserveLimited: Bool
+    let whisperOnly: Bool
+    let targetMet: Bool
+    let unavoidableAtMinimumScale: Bool
+}
+
+enum SerpentineSenseMath {
+    static func evaluate(
+        threat: SerpentineThreat,
+        reserve: Double,
+        tuning: SerpentineSenseTuning = .init()
+    ) -> SerpentineSenseDecision {
+        let decisionBudget = tuning.targetDecisionSeconds
+            * (1 + threat.ambiguity * tuning.ambiguityBudgetMultiplier)
+        let totalBudget = decisionBudget
+            + tuning.cueLatencySeconds
+            + tuning.inputLatencySeconds
+        let requestedScale = clamp(
+            threat.leadSeconds / totalBudget,
+            tuning.minimumTimeScale,
+            1
+        )
+        let confidenceWeight = smoothstep(
+            tuning.minimumAssistConfidence,
+            tuning.fullAssistConfidence,
+            threat.confidence
+        )
+        let assistWeight = clamp(
+            confidenceWeight
+                * threat.severity
+                * (1 - threat.ambiguity * tuning.ambiguityAssistPenalty),
+            0,
+            1
+        )
+        let desiredScale = 1 - (1 - requestedScale) * assistWeight
+        let availableReserve = clamp(reserve, 0, tuning.maximumReserve)
+        let limited = reserveLimitedScale(
+            desiredScale: desiredScale,
+            reserve: availableReserve,
+            threat: threat,
+            tuning: tuning
+        )
+        let realWindow = threat.leadSeconds / limited.scale
+        let usableWindow = max(
+            0,
+            realWindow - tuning.cueLatencySeconds - tuning.inputLatencySeconds
+        )
+        let maximumUsableWindow = max(
+            0,
+            threat.leadSeconds / tuning.minimumTimeScale
+                - tuning.cueLatencySeconds
+                - tuning.inputLatencySeconds
+        )
+
+        return SerpentineSenseDecision(
+            requestedTimeScale: requestedScale,
+            timeScale: limited.scale,
+            realWindowSeconds: realWindow,
+            usableResponseSeconds: usableWindow,
+            requestedDecisionSeconds: decisionBudget,
+            assistWeight: assistWeight,
+            reserveCost: limited.cost,
+            reserveLimited: limited.isLimited,
+            whisperOnly: assistWeight <= 0.000_000_001,
+            targetMet: usableWindow + 0.000_000_001 >= decisionBudget,
+            unavoidableAtMinimumScale:
+                maximumUsableWindow + 0.000_000_001 < decisionBudget
+        )
+    }
+
+    private static func reserveLimitedScale(
+        desiredScale: Double,
+        reserve: Double,
+        threat: SerpentineThreat,
+        tuning: SerpentineSenseTuning
+    ) -> (scale: Double, cost: Double, isLimited: Bool) {
+        let desiredCost = reserveCost(
+            leadSeconds: threat.leadSeconds,
+            timeScale: desiredScale,
+            severity: threat.severity,
+            tuning: tuning
+        )
+        guard desiredCost > reserve + 0.000_000_001 else {
+            return (desiredScale, desiredCost, false)
+        }
+        guard reserve > 0 else {
+            return (1, 0, true)
+        }
+
+        var lower = desiredScale
+        var upper = 1.0
+        for _ in 0..<64 {
+            let candidate = (lower + upper) / 2
+            let candidateCost = reserveCost(
+                leadSeconds: threat.leadSeconds,
+                timeScale: candidate,
+                severity: threat.severity,
+                tuning: tuning
+            )
+            if candidateCost > reserve {
+                lower = candidate
+            } else {
+                upper = candidate
+            }
+        }
+        return (
+            upper,
+            min(
+                reserve,
+                reserveCost(
+                    leadSeconds: threat.leadSeconds,
+                    timeScale: upper,
+                    severity: threat.severity,
+                    tuning: tuning
+                )
+            ),
+            true
+        )
+    }
+
+    private static func reserveCost(
+        leadSeconds: Double,
+        timeScale: Double,
+        severity: Double,
+        tuning: SerpentineSenseTuning
+    ) -> Double {
+        let realWindow = leadSeconds / max(timeScale, 0.000_001)
+        return (
+            tuning.reserveCostRate
+                * (1 - timeScale)
+                * realWindow
+                * (0.5 + 0.5 * severity)
+        )
+    }
+
+    private static func smoothstep(
+        _ edge0: Double,
+        _ edge1: Double,
+        _ value: Double
+    ) -> Double {
+        let normalized = clamp((value - edge0) / (edge1 - edge0), 0, 1)
+        return normalized * normalized * (3 - 2 * normalized)
+    }
+
+    private static func clamp(
+        _ value: Double,
+        _ lower: Double,
+        _ upper: Double
+    ) -> Double {
+        max(lower, min(value, upper))
+    }
+}
+
+@MainActor
+final class SerpentineSenseEngine: ObservableObject {
+    enum Phase: Equatable {
+        case dormant
+        case waiting
+        case sensing
+        case crownFlare
+        case resolved
+        case ruptured
+        case ignored
+    }
+
+    @Published private(set) var phase: Phase = .dormant
+    @Published private(set) var activeThreat: SerpentineThreat?
+    @Published private(set) var decision: SerpentineSenseDecision?
+    @Published private(set) var selectedDirection: ThreatDirection?
+    @Published private(set) var selectedResponse: SerpentineResponse?
+    @Published private(set) var timeRemaining = 0.0
+    @Published private(set) var reserve = 100.0
+    @Published private(set) var score = 0
+    @Published private(set) var coilStreak = 0
+    @Published private(set) var statusMessage =
+        "Wake the crown. Read pressure, aura, code, and hex."
+
+    let tuning = SerpentineSenseTuning()
+
+    private var countdownTimer: Timer?
+    private var launchTimer: Timer?
+    private var lastTick: Date?
+
+    var isThreatActive: Bool {
+        phase == .sensing || phase == .crownFlare
+    }
+
+    var canSelectResponse: Bool {
+        guard let threat = activeThreat else { return false }
+        return isThreatActive && selectedDirection == threat.direction
+    }
+
+    var primaryActionTitle: String {
+        switch phase {
+        case .dormant: return "Wake the Crown"
+        case .waiting: return "Listening…"
+        case .sensing, .crownFlare: return "Threat in Motion"
+        case .resolved, .ruptured, .ignored: return "Read Next Omen"
+        }
+    }
+
+    func primaryAction() {
+        switch phase {
+        case .dormant:
+            beginCalibration()
+        case .resolved, .ruptured, .ignored:
+            scheduleNextThreat(after: 0.35)
+        case .waiting, .sensing, .crownFlare:
+            break
+        }
+    }
+
+    func beginCalibration() {
+        invalidateTimers()
+        score = 0
+        coilStreak = 0
+        reserve = tuning.maximumReserve
+        statusMessage = "The crown opens across eight directions."
+        scheduleNextThreat(after: 0.55)
+    }
+
+    func choose(direction: ThreatDirection) {
+        guard isThreatActive, let threat = activeThreat else { return }
+        selectedDirection = direction
+        guard direction == threat.direction else {
+            finish(
+                success: false,
+                message: "False coil. The omen arrived from \(threat.direction.spokenLabel)."
+            )
+            return
+        }
+        statusMessage =
+            "Source locked: \(direction.spokenLabel). Choose how the Gorgon answers."
+    }
+
+    func choose(response: SerpentineResponse) {
+        guard canSelectResponse, let threat = activeThreat else { return }
+        selectedResponse = response
+        guard response == threat.family.correctResponse else {
+            finish(
+                success: false,
+                message:
+                    "The channel crossed. \(threat.family.correctResponse.title) was the clean answer."
+            )
+            return
+        }
+        finish(
+            success: true,
+            message:
+                "\(response.title) braided through \(threat.channel.title). Omen resolved."
+        )
+    }
+
+    func ignoreCurrentThreat() {
+        guard isThreatActive else { return }
+        invalidateTimers()
+        coilStreak = max(0, coilStreak - 1)
+        reserve = min(tuning.maximumReserve, reserve + 1)
+        phase = .ignored
+        statusMessage = "Omen released. You kept agency—and accepted its consequence."
+    }
+
+    func pause() {
+        invalidateTimers()
+        activeThreat = nil
+        decision = nil
+        selectedDirection = nil
+        selectedResponse = nil
+        timeRemaining = 0
+        phase = .dormant
+        statusMessage = "Wake the crown. Read pressure, aura, code, and hex."
+    }
+
+    private func scheduleNextThreat(after delay: TimeInterval) {
+        invalidateTimers()
+        activeThreat = nil
+        decision = nil
+        selectedDirection = nil
+        selectedResponse = nil
+        timeRemaining = 0
+        phase = .waiting
+        statusMessage = "Coils listening across the aether…"
+
+        launchTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) {
+            [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.launchThreat()
+            }
+        }
+    }
+
+    private func launchThreat() {
+        let threat = makeThreat()
+        let senseDecision = SerpentineSenseMath.evaluate(
+            threat: threat,
+            reserve: reserve,
+            tuning: tuning
+        )
+        activeThreat = threat
+        decision = senseDecision
+        selectedDirection = nil
+        selectedResponse = nil
+        timeRemaining = threat.leadSeconds
+        reserve = max(0, reserve - senseDecision.reserveCost)
+        phase = senseDecision.timeScale < 0.98 ? .crownFlare : .sensing
+
+        if senseDecision.whisperOnly {
+            statusMessage =
+                "Whisper only: uncertain \(threat.channel.title.lowercased()) signal."
+        } else if senseDecision.unavoidableAtMinimumScale {
+            statusMessage = "Late prophecy. Choose now—the crown cannot make enough time."
+        } else {
+            statusMessage =
+                "\(threat.channel.title) flares from \(threat.direction.spokenLabel)."
+        }
+
+        lastTick = Date()
+        let timer = Timer(timeInterval: 0.05, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.tick()
+            }
+        }
+        countdownTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    private func tick() {
+        guard isThreatActive, let decision else { return }
+        let now = Date()
+        let realDelta = min(0.20, now.timeIntervalSince(lastTick ?? now))
+        lastTick = now
+        timeRemaining = max(0, timeRemaining - realDelta * decision.timeScale)
+        if timeRemaining <= 0 {
+            finish(success: false, message: "The omen crossed the threshold unanswered.")
+        }
+    }
+
+    private func finish(success: Bool, message: String) {
+        guard isThreatActive, let threat = activeThreat else { return }
+        invalidateTimers()
+        if success {
+            coilStreak += 1
+            let remainingRatio = threat.leadSeconds > 0
+                ? timeRemaining / threat.leadSeconds
+                : 0
+            let base = Int((threat.severity * 100).rounded())
+            let velocity = Int((max(0, remainingRatio) * 50).rounded())
+            score += base + velocity + coilStreak * 10
+            reserve = min(tuning.maximumReserve, reserve + 3.5)
+            phase = .resolved
+        } else {
+            coilStreak = 0
+            reserve = min(tuning.maximumReserve, reserve + 1.5)
+            phase = .ruptured
+        }
+        statusMessage = message
+    }
+
+    private func makeThreat() -> SerpentineThreat {
+        let family = ThreatFamily.allCases.randomElement() ?? .kineticFracture
+        let direction = ThreatDirection.allCases.randomElement() ?? .north
+        let leadOptions = [0.24, 0.34, 0.48, 0.68, 0.95, 1.25, 1.60]
+        return SerpentineThreat(
+            family: family,
+            direction: direction,
+            leadSeconds: leadOptions.randomElement() ?? 0.68,
+            severity: Double.random(in: 0.58...1.0),
+            confidence: Double.random(in: 0.36...1.0),
+            ambiguity: Double.random(in: 0...0.38)
+        )
+    }
+
+    private func invalidateTimers() {
+        countdownTimer?.invalidate()
+        launchTimer?.invalidate()
+        countdownTimer = nil
+        launchTimer = nil
+        lastTick = nil
+    }
+}

--- a/ios/ReincarneLogicGame/SerpentineSenseView.swift
+++ b/ios/ReincarneLogicGame/SerpentineSenseView.swift
@@ -1,0 +1,562 @@
+import AVFoundation
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+@MainActor
+final class SerpentineCueController: ObservableObject {
+    private let audioEngine = AVAudioEngine()
+    private let player = AVAudioPlayerNode()
+    private var isAudioConfigured = false
+
+    func fire(
+        threat: SerpentineThreat,
+        decision: SerpentineSenseDecision,
+        soundEnabled: Bool,
+        hapticsEnabled: Bool
+    ) {
+        if hapticsEnabled {
+            fireHaptic(severity: threat.severity, isCrownFlare: decision.timeScale < 0.98)
+        }
+        if soundEnabled {
+            playDirectionalTone(for: threat)
+        }
+    }
+
+    private func fireHaptic(severity: Double, isCrownFlare: Bool) {
+        #if canImport(UIKit)
+        let style: UIImpactFeedbackGenerator.FeedbackStyle = isCrownFlare ? .rigid : .medium
+        let generator = UIImpactFeedbackGenerator(style: style)
+        generator.prepare()
+        generator.impactOccurred(intensity: CGFloat(0.45 + severity * 0.55))
+        #endif
+    }
+
+    private func configureAudioIfNeeded() throws {
+        guard !isAudioConfigured else { return }
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.ambient, mode: .default, options: [.mixWithOthers])
+        try session.setActive(true)
+        audioEngine.attach(player)
+        audioEngine.connect(player, to: audioEngine.mainMixerNode, format: nil)
+        audioEngine.prepare()
+        try audioEngine.start()
+        isAudioConfigured = true
+    }
+
+    private func playDirectionalTone(for threat: SerpentineThreat) {
+        do {
+            try configureAudioIfNeeded()
+            if !audioEngine.isRunning {
+                try audioEngine.start()
+            }
+        } catch {
+            return
+        }
+
+        let sampleRate = 44_100.0
+        let duration = 0.16
+        let frameCount = AVAudioFrameCount(sampleRate * duration)
+        guard
+            let format = AVAudioFormat(
+                standardFormatWithSampleRate: sampleRate,
+                channels: 2
+            ),
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: frameCount
+            ),
+            let channels = buffer.floatChannelData
+        else { return }
+
+        buffer.frameLength = frameCount
+        let verticalPitch: Double
+        switch threat.direction {
+        case .north, .northEast, .northWest:
+            verticalPitch = 1.16
+        case .south, .southEast, .southWest:
+            verticalPitch = 0.86
+        case .east, .west:
+            verticalPitch = 1.0
+        }
+
+        let panAngle = (threat.direction.stereoPan + 1) * .pi / 4
+        let leftGain = cos(panAngle)
+        let rightGain = sin(panAngle)
+        let baseFrequency = threat.channel.toneFrequency * verticalPitch
+
+        for frame in 0..<Int(frameCount) {
+            let time = Double(frame) / sampleRate
+            let progress = time / duration
+            let sweep = threat.channel == .hexEcho
+                ? 1.18 - progress * 0.42
+                : 0.94 + progress * 0.18
+            let attack = min(1, progress / 0.06)
+            let decay = pow(max(0, 1 - progress), 2.2)
+            let envelope = attack * decay
+            let fundamental = sin(2 * .pi * baseFrequency * sweep * time)
+            let harmonic = 0.28 * sin(2 * .pi * baseFrequency * 2.01 * time)
+            let sample = Float((fundamental + harmonic) * envelope * 0.24)
+            channels[0][frame] = sample * Float(leftGain)
+            channels[1][frame] = sample * Float(rightGain)
+        }
+
+        player.stop()
+        player.scheduleBuffer(buffer, at: nil, options: .interrupts)
+        player.play()
+    }
+}
+
+struct SerpentineSenseView: View {
+    @StateObject private var engine = SerpentineSenseEngine()
+    @StateObject private var cueController = SerpentineCueController()
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var soundEnabled = true
+    @State private var hapticsEnabled = true
+
+    private let responseColumns = [
+        GridItem(.flexible(), spacing: 10),
+        GridItem(.flexible(), spacing: 10)
+    ]
+
+    var body: some View {
+        ZStack {
+            aetherBackground
+            ScrollView {
+                VStack(spacing: 18) {
+                    masthead
+                    statRail
+                    omenCard
+                    compass
+                    responseGrid
+                    controls
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 18)
+                .padding(.bottom, 30)
+            }
+        }
+        .onChange(of: engine.activeThreat?.id) { _ in
+            guard
+                let threat = engine.activeThreat,
+                let decision = engine.decision
+            else { return }
+            cueController.fire(
+                threat: threat,
+                decision: decision,
+                soundEnabled: soundEnabled,
+                hapticsEnabled: hapticsEnabled
+            )
+        }
+        .onDisappear {
+            engine.pause()
+        }
+    }
+
+    private var aetherBackground: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(red: 0.025, green: 0.018, blue: 0.055),
+                    Color(red: 0.08, green: 0.025, blue: 0.15),
+                    Color(red: 0.015, green: 0.12, blue: 0.11)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            RadialGradient(
+                colors: [aetherGold.opacity(0.16), .clear],
+                center: .topTrailing,
+                startRadius: 10,
+                endRadius: 340
+            )
+            .blendMode(.screen)
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .trim(
+                        from: 0.06 + CGFloat(index) * 0.05,
+                        to: 0.62 + CGFloat(index) * 0.06
+                    )
+                    .stroke(
+                        index.isMultiple(of: 2) ? aetherJade.opacity(0.12) : aetherViolet.opacity(0.13),
+                        style: StrokeStyle(lineWidth: 1.2, dash: [3, 12])
+                    )
+                    .rotationEffect(.degrees(Double(index) * 73))
+                    .scaleEffect(0.7 + CGFloat(index) * 0.22)
+            }
+            .allowsHitTesting(false)
+        }
+        .ignoresSafeArea()
+    }
+
+    private var masthead: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("SERPENTINE SENSE")
+                    .font(.system(.title, design: .rounded, weight: .black))
+                    .tracking(1.4)
+                    .foregroundStyle(.white)
+                Spacer()
+                Text("AETHERCOIL // 01")
+                    .font(.caption2.monospaced().bold())
+                    .foregroundStyle(aetherGold)
+            }
+            Text("Afro-Gorgon cognition across aura, sorcery, instinct, and machine prophecy.")
+                .font(.subheadline)
+                .foregroundStyle(.white.opacity(0.68))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var statRail: some View {
+        HStack(spacing: 9) {
+            statCell(
+                label: "RESERVE",
+                value: "\(Int(engine.reserve.rounded()))",
+                accent: aetherJade
+            )
+            statCell(
+                label: "COIL",
+                value: "×\(engine.coilStreak)",
+                accent: aetherViolet
+            )
+            statCell(
+                label: "SCORE",
+                value: "\(engine.score)",
+                accent: aetherGold
+            )
+        }
+    }
+
+    private func statCell(label: String, value: String, accent: Color) -> some View {
+        VStack(spacing: 3) {
+            Text(label)
+                .font(.caption2.monospaced().bold())
+                .foregroundStyle(.white.opacity(0.52))
+            Text(value)
+                .font(.headline.monospacedDigit().bold())
+                .foregroundStyle(accent)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 10)
+        .background(panelBackground)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(accent.opacity(0.75))
+                .frame(height: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
+    }
+
+    private var omenCard: some View {
+        VStack(alignment: .leading, spacing: 11) {
+            HStack {
+                if let threat = engine.activeThreat {
+                    Text(threat.family.glyph)
+                        .font(.title2)
+                        .foregroundStyle(aetherGold)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(threat.family.title.uppercased())
+                            .font(.caption.monospaced().bold())
+                            .foregroundStyle(.white)
+                        Text("\(threat.channel.glyph) \(threat.channel.title)")
+                            .font(.caption)
+                            .foregroundStyle(aetherJade)
+                    }
+                } else {
+                    Text("◉")
+                        .font(.title2)
+                        .foregroundStyle(aetherViolet)
+                    Text("CROWN DORMANT")
+                        .font(.caption.monospaced().bold())
+                        .foregroundStyle(.white)
+                }
+                Spacer()
+                if let decision = engine.decision {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text(String(format: "%.2f× WORLD", decision.timeScale))
+                            .font(.caption.monospaced().bold())
+                            .foregroundStyle(decision.timeScale < 0.98 ? aetherGold : .white)
+                        Text(String(format: "%.0f%% CERTAINTY", (engine.activeThreat?.confidence ?? 0) * 100))
+                            .font(.caption2.monospaced())
+                            .foregroundStyle(.white.opacity(0.58))
+                    }
+                }
+            }
+
+            Text(engine.statusMessage)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.white.opacity(0.86))
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let threat = engine.activeThreat {
+                ProgressView(
+                    value: engine.timeRemaining,
+                    total: max(0.001, threat.leadSeconds)
+                )
+                .tint(engine.phase == .crownFlare ? aetherGold : aetherJade)
+                .accessibilityLabel("Threat time remaining")
+                .accessibilityValue(String(format: "%.2f seconds", engine.timeRemaining))
+            }
+        }
+        .padding(14)
+        .background(panelBackground)
+        .overlay {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(aetherViolet.opacity(0.28), lineWidth: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
+
+    private var compass: some View {
+        GeometryReader { proxy in
+            let side = min(proxy.size.width, proxy.size.height)
+            let center = CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2)
+            let radius = side * 0.39
+
+            ZStack {
+                Circle()
+                    .stroke(aetherJade.opacity(0.15), lineWidth: 1)
+                    .frame(width: side * 0.78, height: side * 0.78)
+                Circle()
+                    .stroke(
+                        aetherViolet.opacity(0.32),
+                        style: StrokeStyle(lineWidth: 1, dash: [2, 8])
+                    )
+                    .frame(width: side * 0.58, height: side * 0.58)
+                    .rotationEffect(.degrees(reduceMotion ? 0 : 16))
+
+                ForEach(ThreatDirection.allCases) { direction in
+                    directionButton(direction)
+                        .position(
+                            x: center.x + CGFloat(cos(direction.angleRadians)) * radius,
+                            y: center.y + CGFloat(sin(direction.angleRadians)) * radius
+                        )
+                }
+
+                crownCore
+                    .position(center)
+            }
+        }
+        .frame(height: 310)
+        .padding(.horizontal, 8)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Eight-direction Serpentine Sense compass")
+    }
+
+    private func directionButton(_ direction: ThreatDirection) -> some View {
+        let isSelected = engine.selectedDirection == direction
+        let isThreat = engine.isThreatActive && engine.activeThreat?.direction == direction
+
+        return Button {
+            engine.choose(direction: direction)
+        } label: {
+            ZStack {
+                Circle()
+                    .fill(
+                        isSelected
+                            ? aetherGold.opacity(0.95)
+                            : isThreat
+                                ? aetherViolet.opacity(0.72)
+                                : Color.black.opacity(0.46)
+                    )
+                Circle()
+                    .stroke(
+                        isThreat ? aetherGold.opacity(0.8) : .white.opacity(0.12),
+                        lineWidth: isThreat ? 2 : 1
+                    )
+                Text(direction.shortLabel)
+                    .font(.caption2.monospaced().bold())
+                    .foregroundStyle(isSelected ? Color.black : Color.white)
+            }
+            .frame(width: 48, height: 48)
+            .shadow(color: isThreat ? aetherViolet.opacity(0.8) : .clear, radius: 12)
+        }
+        .buttonStyle(.plain)
+        .disabled(!engine.isThreatActive)
+        .accessibilityLabel("\(direction.spokenLabel) direction")
+        .accessibilityHint(isThreat ? "Serpentine cue detected here" : "Select threat source")
+    }
+
+    private var crownCore: some View {
+        ZStack {
+            Circle()
+                .fill(
+                    RadialGradient(
+                        colors: [
+                            (engine.phase == .crownFlare ? aetherGold : aetherViolet).opacity(0.45),
+                            Color.black.opacity(0.82)
+                        ],
+                        center: .center,
+                        startRadius: 2,
+                        endRadius: 74
+                    )
+                )
+            Circle()
+                .stroke(aetherGold.opacity(0.5), lineWidth: 1)
+                .padding(7)
+            VStack(spacing: 1) {
+                Text(engine.phase == .crownFlare ? "CROWN FLARE" : "AETHERCOIL")
+                    .font(.caption2.monospaced().bold())
+                    .foregroundStyle(aetherGold)
+                if engine.activeThreat != nil {
+                    Text(String(format: "%.2f", engine.timeRemaining))
+                        .font(.title2.monospacedDigit().bold())
+                        .foregroundStyle(.white)
+                    Text("WORLD SEC")
+                        .font(.system(size: 8, weight: .bold, design: .monospaced))
+                        .foregroundStyle(.white.opacity(0.5))
+                } else {
+                    Text("◉")
+                        .font(.title.bold())
+                        .foregroundStyle(.white)
+                }
+            }
+        }
+        .frame(width: 126, height: 126)
+        .shadow(color: aetherViolet.opacity(0.5), radius: 24)
+    }
+
+    private var responseGrid: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack {
+                Text("CHANNEL RESPONSE")
+                    .font(.caption.monospaced().bold())
+                    .foregroundStyle(.white.opacity(0.58))
+                Spacer()
+                if engine.isThreatActive && !engine.canSelectResponse {
+                    Text("LOCK DIRECTION FIRST")
+                        .font(.caption2.monospaced().bold())
+                        .foregroundStyle(aetherGold.opacity(0.82))
+                }
+            }
+
+            LazyVGrid(columns: responseColumns, spacing: 10) {
+                ForEach(SerpentineResponse.allCases) { response in
+                    Button {
+                        engine.choose(response: response)
+                    } label: {
+                        HStack(spacing: 9) {
+                            Text(response.glyph)
+                                .font(.title3.bold())
+                                .frame(width: 24)
+                            VStack(alignment: .leading, spacing: 1) {
+                                Text(response.title.uppercased())
+                                    .font(.caption.monospaced().bold())
+                                Text(response.instruction)
+                                    .font(.system(size: 9, weight: .medium))
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.75)
+                                    .opacity(0.6)
+                            }
+                            Spacer(minLength: 0)
+                        }
+                        .foregroundStyle(
+                            engine.selectedResponse == response ? Color.black : Color.white
+                        )
+                        .padding(.horizontal, 11)
+                        .frame(maxWidth: .infinity, minHeight: 54)
+                        .background(
+                            engine.selectedResponse == response
+                                ? aetherGold
+                                : Color.white.opacity(0.07)
+                        )
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                                .stroke(.white.opacity(0.10), lineWidth: 1)
+                        }
+                        .clipShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!engine.canSelectResponse)
+                    .opacity(engine.canSelectResponse ? 1 : 0.45)
+                }
+            }
+        }
+    }
+
+    private var controls: some View {
+        VStack(spacing: 11) {
+            HStack(spacing: 10) {
+                modalityToggle(
+                    title: "Audio",
+                    systemImage: soundEnabled ? "speaker.wave.2.fill" : "speaker.slash.fill",
+                    isOn: $soundEnabled
+                )
+                modalityToggle(
+                    title: "Haptics",
+                    systemImage: hapticsEnabled ? "waveform.path" : "waveform.slash",
+                    isOn: $hapticsEnabled
+                )
+            }
+
+            Button {
+                engine.primaryAction()
+            } label: {
+                Text(engine.primaryActionTitle.uppercased())
+                    .font(.headline.monospaced().bold())
+                    .tracking(0.8)
+                    .foregroundStyle(Color.black)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 15)
+                    .background(aetherGold)
+                    .clipShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .disabled(engine.isThreatActive || engine.phase == .waiting)
+            .opacity(engine.isThreatActive || engine.phase == .waiting ? 0.48 : 1)
+
+            if engine.isThreatActive {
+                Button("Let the omen pass") {
+                    engine.ignoreCurrentThreat()
+                }
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.white.opacity(0.62))
+                .accessibilityHint("Ignore this cue and preserve player agency")
+            }
+        }
+    }
+
+    private func modalityToggle(
+        title: String,
+        systemImage: String,
+        isOn: Binding<Bool>
+    ) -> some View {
+        Button {
+            isOn.wrappedValue.toggle()
+        } label: {
+            Label(title, systemImage: systemImage)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(isOn.wrappedValue ? aetherJade : .white.opacity(0.45))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 9)
+                .background(Color.white.opacity(0.06))
+                .clipShape(RoundedRectangle(cornerRadius: 11, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityValue(isOn.wrappedValue ? "On" : "Off")
+    }
+
+    private var panelBackground: some ShapeStyle {
+        Color.black.opacity(0.34)
+    }
+
+    private var aetherGold: Color {
+        Color(red: 0.96, green: 0.73, blue: 0.25)
+    }
+
+    private var aetherJade: Color {
+        Color(red: 0.20, green: 0.91, blue: 0.69)
+    }
+
+    private var aetherViolet: Color {
+        Color(red: 0.69, green: 0.31, blue: 1.0)
+    }
+}
+
+#Preview {
+    SerpentineSenseView()
+}

--- a/simulation/serpentine_sense_balance.py
+++ b/simulation/serpentine_sense_balance.py
@@ -1,0 +1,369 @@
+"""Deterministic balance model for Reincarne Logic's Serpentine Sense.
+
+The model answers one narrow question: given a predicted threat lead time and a
+player response budget, how much world-time dilation is justified? It is kept
+free of game-engine dependencies so designers can sweep values in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Iterable
+
+
+class SenseChannel(str, Enum):
+    COIL_INSTINCT = "coil_instinct"
+    AURA_SIGHT = "aura_sight"
+    AETHERWARE_ORACLE = "aetherware_oracle"
+    HEX_ECHO = "hex_echo"
+
+
+class ThreatFamily(str, Enum):
+    KINETIC_FRACTURE = "kinetic_fracture"
+    AURA_PREDATION = "aura_predation"
+    HEX_WEAVE = "hex_weave"
+    AETHER_SURGE = "aether_surge"
+    CYBER_INTRUSION = "cyber_intrusion"
+
+
+def clamp(value: float, lower: float, upper: float) -> float:
+    return max(lower, min(value, upper))
+
+
+def smoothstep(edge0: float, edge1: float, value: float) -> float:
+    if edge0 >= edge1:
+        raise ValueError("smoothstep requires edge0 < edge1")
+    normalized = clamp((value - edge0) / (edge1 - edge0), 0.0, 1.0)
+    return normalized * normalized * (3.0 - 2.0 * normalized)
+
+
+@dataclass(frozen=True)
+class SenseTuning:
+    """Player-facing and resource-facing tuning values.
+
+    All latency and budget values are in real seconds. ``min_time_scale`` is
+    world seconds advanced per real second, so 0.10 means 10% world speed.
+    """
+
+    target_decision_seconds: float = 0.90
+    cue_latency_seconds: float = 0.17
+    input_latency_seconds: float = 0.08
+    min_time_scale: float = 0.10
+    min_assist_confidence: float = 0.45
+    full_assist_confidence: float = 0.85
+    ambiguity_budget_multiplier: float = 0.35
+    ambiguity_assist_penalty: float = 0.35
+    reserve_cost_rate: float = 7.5
+    max_reserve: float = 100.0
+
+    def __post_init__(self) -> None:
+        positive = {
+            "target_decision_seconds": self.target_decision_seconds,
+            "cue_latency_seconds": self.cue_latency_seconds,
+            "input_latency_seconds": self.input_latency_seconds,
+            "reserve_cost_rate": self.reserve_cost_rate,
+            "max_reserve": self.max_reserve,
+        }
+        if any(value < 0 for value in positive.values()):
+            raise ValueError("time and reserve tuning values cannot be negative")
+        if not 0 < self.min_time_scale <= 1:
+            raise ValueError("min_time_scale must be in (0, 1]")
+        if not 0 <= self.min_assist_confidence < self.full_assist_confidence <= 1:
+            raise ValueError("confidence thresholds must satisfy 0 <= min < full <= 1")
+        if not 0 <= self.ambiguity_assist_penalty <= 1:
+            raise ValueError("ambiguity_assist_penalty must be in [0, 1]")
+
+
+@dataclass(frozen=True)
+class ThreatSignature:
+    lead_seconds: float
+    severity: float
+    confidence: float
+    ambiguity: float = 0.0
+    family: ThreatFamily = ThreatFamily.KINETIC_FRACTURE
+    channel: SenseChannel = SenseChannel.COIL_INSTINCT
+
+    def __post_init__(self) -> None:
+        if self.lead_seconds < 0:
+            raise ValueError("lead_seconds cannot be negative")
+        for name in ("severity", "confidence", "ambiguity"):
+            value = getattr(self, name)
+            if not 0 <= value <= 1:
+                raise ValueError(f"{name} must be in [0, 1]")
+
+
+@dataclass(frozen=True)
+class SenseDecision:
+    requested_time_scale: float
+    time_scale: float
+    real_window_seconds: float
+    usable_response_seconds: float
+    requested_decision_seconds: float
+    assist_weight: float
+    reserve_cost: float
+    reserve_limited: bool
+    whisper_only: bool
+    target_met: bool
+    unavoidable_at_minimum_scale: bool
+
+
+def requested_decision_budget(
+    threat: ThreatSignature, tuning: SenseTuning
+) -> float:
+    """Increase deliberation time slightly when the signal is ambiguous."""
+
+    return tuning.target_decision_seconds * (
+        1.0 + threat.ambiguity * tuning.ambiguity_budget_multiplier
+    )
+
+
+def reserve_cost(
+    *, lead_seconds: float, time_scale: float, severity: float, tuning: SenseTuning
+) -> float:
+    """Cost of maintaining Crown Flare for this threat.
+
+    Cost approaches zero at normal time and rises with both slowdown duration
+    and threat severity.
+    """
+
+    if time_scale <= 0:
+        raise ValueError("time_scale must be positive")
+    real_window = lead_seconds / time_scale
+    return (
+        tuning.reserve_cost_rate
+        * (1.0 - time_scale)
+        * real_window
+        * (0.5 + 0.5 * severity)
+    )
+
+
+def _reserve_limited_scale(
+    *,
+    desired_scale: float,
+    reserve: float,
+    threat: ThreatSignature,
+    tuning: SenseTuning,
+) -> tuple[float, float, bool]:
+    desired_cost = reserve_cost(
+        lead_seconds=threat.lead_seconds,
+        time_scale=desired_scale,
+        severity=threat.severity,
+        tuning=tuning,
+    )
+    if desired_cost <= reserve + 1e-9:
+        return desired_scale, desired_cost, False
+    if reserve <= 0:
+        return 1.0, 0.0, True
+
+    # Cost decreases monotonically as scale approaches 1. Binary search finds
+    # the strongest slowdown the current reserve can actually fund.
+    lower = desired_scale
+    upper = 1.0
+    for _ in range(64):
+        candidate = (lower + upper) / 2.0
+        candidate_cost = reserve_cost(
+            lead_seconds=threat.lead_seconds,
+            time_scale=candidate,
+            severity=threat.severity,
+            tuning=tuning,
+        )
+        if candidate_cost > reserve:
+            lower = candidate
+        else:
+            upper = candidate
+
+    final_scale = upper
+    final_cost = min(
+        reserve,
+        reserve_cost(
+            lead_seconds=threat.lead_seconds,
+            time_scale=final_scale,
+            severity=threat.severity,
+            tuning=tuning,
+        ),
+    )
+    return final_scale, final_cost, True
+
+
+def evaluate_threat(
+    threat: ThreatSignature,
+    *,
+    reserve: float = 100.0,
+    tuning: SenseTuning | None = None,
+) -> SenseDecision:
+    tuning = tuning or SenseTuning()
+    if reserve < 0:
+        raise ValueError("reserve cannot be negative")
+    reserve = min(reserve, tuning.max_reserve)
+
+    decision_budget = requested_decision_budget(threat, tuning)
+    total_budget = (
+        decision_budget
+        + tuning.cue_latency_seconds
+        + tuning.input_latency_seconds
+    )
+    requested_scale = clamp(
+        threat.lead_seconds / total_budget if total_budget > 0 else 1.0,
+        tuning.min_time_scale,
+        1.0,
+    )
+
+    confidence_weight = smoothstep(
+        tuning.min_assist_confidence,
+        tuning.full_assist_confidence,
+        threat.confidence,
+    )
+    assist_weight = (
+        confidence_weight
+        * threat.severity
+        * (1.0 - threat.ambiguity * tuning.ambiguity_assist_penalty)
+    )
+    assist_weight = clamp(assist_weight, 0.0, 1.0)
+    whisper_only = assist_weight <= 1e-9
+
+    desired_scale = 1.0 - (1.0 - requested_scale) * assist_weight
+    time_scale, cost, reserve_limited = _reserve_limited_scale(
+        desired_scale=desired_scale,
+        reserve=reserve,
+        threat=threat,
+        tuning=tuning,
+    )
+
+    real_window = threat.lead_seconds / time_scale
+    usable_window = max(
+        0.0,
+        real_window
+        - tuning.cue_latency_seconds
+        - tuning.input_latency_seconds,
+    )
+    max_usable_window = max(
+        0.0,
+        threat.lead_seconds / tuning.min_time_scale
+        - tuning.cue_latency_seconds
+        - tuning.input_latency_seconds,
+    )
+
+    return SenseDecision(
+        requested_time_scale=requested_scale,
+        time_scale=time_scale,
+        real_window_seconds=real_window,
+        usable_response_seconds=usable_window,
+        requested_decision_seconds=decision_budget,
+        assist_weight=assist_weight,
+        reserve_cost=cost,
+        reserve_limited=reserve_limited,
+        whisper_only=whisper_only,
+        target_met=usable_window + 1e-9 >= decision_budget,
+        unavoidable_at_minimum_scale=max_usable_window + 1e-9 < decision_budget,
+    )
+
+
+def estimate_success_rate(
+    decision: SenseDecision,
+    *,
+    samples: int = 10_000,
+    mean_choice_seconds: float = 0.72,
+    choice_standard_deviation: float = 0.14,
+    cue_accuracy: float = 0.95,
+    seed: int = 7,
+) -> float:
+    """Estimate timing-and-interpretation success for a synthetic cohort.
+
+    This is a tuning aid, not a model of any individual player. Production
+    accessibility must use player-selected budgets rather than inferred traits.
+    """
+
+    if samples <= 0:
+        raise ValueError("samples must be positive")
+    if mean_choice_seconds <= 0 or choice_standard_deviation < 0:
+        raise ValueError("reaction-time distribution is invalid")
+    if not 0 <= cue_accuracy <= 1:
+        raise ValueError("cue_accuracy must be in [0, 1]")
+
+    generator = random.Random(seed)
+    successes = 0
+    for _ in range(samples):
+        choice_time = max(
+            0.05,
+            generator.gauss(mean_choice_seconds, choice_standard_deviation),
+        )
+        in_time = choice_time <= decision.usable_response_seconds
+        interpreted = generator.random() <= cue_accuracy
+        successes += int(in_time and interpreted)
+    return successes / samples
+
+
+def default_matrix() -> Iterable[tuple[ThreatSignature, SenseDecision]]:
+    tuning = SenseTuning()
+    for lead in (0.15, 0.30, 0.60, 1.20, 2.40):
+        for confidence in (0.40, 0.65, 0.90):
+            threat = ThreatSignature(
+                lead_seconds=lead,
+                severity=0.85,
+                confidence=confidence,
+                ambiguity=0.15,
+            )
+            yield threat, evaluate_threat(threat, tuning=tuning)
+
+
+def _print_matrix() -> None:
+    print("lead  conf  scale  usable  cost  assist  target  mode")
+    for threat, decision in default_matrix():
+        mode = "whisper" if decision.whisper_only else "crown-flare"
+        print(
+            f"{threat.lead_seconds:>4.2f}  "
+            f"{threat.confidence:>4.2f}  "
+            f"{decision.time_scale:>5.2f}  "
+            f"{decision.usable_response_seconds:>6.2f}  "
+            f"{decision.reserve_cost:>4.1f}  "
+            f"{decision.assist_weight:>6.2f}  "
+            f"{str(decision.target_met):>6}  "
+            f"{mode}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lead", type=float)
+    parser.add_argument("--severity", type=float, default=0.85)
+    parser.add_argument("--confidence", type=float, default=0.90)
+    parser.add_argument("--ambiguity", type=float, default=0.10)
+    parser.add_argument("--reserve", type=float, default=100.0)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    if args.lead is None:
+        _print_matrix()
+        return
+
+    threat = ThreatSignature(
+        lead_seconds=args.lead,
+        severity=args.severity,
+        confidence=args.confidence,
+        ambiguity=args.ambiguity,
+    )
+    decision = evaluate_threat(threat, reserve=args.reserve)
+    payload = {
+        "threat": {
+            **asdict(threat),
+            "family": threat.family.value,
+            "channel": threat.channel.value,
+        },
+        "decision": asdict(decision),
+        "estimated_success_rate": estimate_success_rate(decision),
+    }
+    if args.as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        for key, value in payload["decision"].items():
+            print(f"{key}: {value}")
+        print(f"estimated_success_rate: {payload['estimated_success_rate']:.3f}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/simulation/test_serpentine_sense_balance.py
+++ b/simulation/test_serpentine_sense_balance.py
@@ -1,0 +1,142 @@
+import unittest
+
+from serpentine_sense_balance import (
+    SenseTuning,
+    ThreatSignature,
+    estimate_success_rate,
+    evaluate_threat,
+    smoothstep,
+)
+
+
+class SerpentineSenseBalanceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tuning = SenseTuning()
+
+    def test_long_lead_needs_no_dilation(self) -> None:
+        decision = evaluate_threat(
+            ThreatSignature(
+                lead_seconds=2.0,
+                severity=1.0,
+                confidence=1.0,
+            ),
+            tuning=self.tuning,
+        )
+        self.assertEqual(decision.time_scale, 1.0)
+        self.assertEqual(decision.reserve_cost, 0.0)
+        self.assertTrue(decision.target_met)
+
+    def test_high_confidence_short_lead_creates_target_window(self) -> None:
+        decision = evaluate_threat(
+            ThreatSignature(
+                lead_seconds=0.30,
+                severity=1.0,
+                confidence=1.0,
+            ),
+            tuning=self.tuning,
+        )
+        self.assertAlmostEqual(decision.time_scale, 0.30 / 1.15, places=6)
+        self.assertAlmostEqual(decision.usable_response_seconds, 0.90, places=6)
+        self.assertTrue(decision.target_met)
+        self.assertGreater(decision.reserve_cost, 0)
+
+    def test_minimum_scale_marks_impossible_forecast(self) -> None:
+        decision = evaluate_threat(
+            ThreatSignature(
+                lead_seconds=0.05,
+                severity=1.0,
+                confidence=1.0,
+            ),
+            tuning=self.tuning,
+        )
+        self.assertAlmostEqual(
+            decision.time_scale,
+            self.tuning.min_time_scale,
+            places=12,
+        )
+        self.assertTrue(decision.unavoidable_at_minimum_scale)
+        self.assertFalse(decision.target_met)
+
+    def test_low_confidence_is_whisper_only(self) -> None:
+        decision = evaluate_threat(
+            ThreatSignature(
+                lead_seconds=0.30,
+                severity=1.0,
+                confidence=0.30,
+            ),
+            tuning=self.tuning,
+        )
+        self.assertTrue(decision.whisper_only)
+        self.assertEqual(decision.time_scale, 1.0)
+        self.assertEqual(decision.reserve_cost, 0.0)
+
+    def test_severity_monotonically_strengthens_assistance(self) -> None:
+        low = evaluate_threat(
+            ThreatSignature(0.30, severity=0.35, confidence=1.0),
+            tuning=self.tuning,
+        )
+        high = evaluate_threat(
+            ThreatSignature(0.30, severity=0.95, confidence=1.0),
+            tuning=self.tuning,
+        )
+        self.assertLess(high.time_scale, low.time_scale)
+        self.assertGreater(high.assist_weight, low.assist_weight)
+
+    def test_empty_reserve_disables_dilation(self) -> None:
+        decision = evaluate_threat(
+            ThreatSignature(0.30, severity=1.0, confidence=1.0),
+            reserve=0,
+            tuning=self.tuning,
+        )
+        self.assertTrue(decision.reserve_limited)
+        self.assertEqual(decision.time_scale, 1.0)
+        self.assertEqual(decision.reserve_cost, 0.0)
+
+    def test_partial_reserve_never_overspends(self) -> None:
+        decision = evaluate_threat(
+            ThreatSignature(0.30, severity=1.0, confidence=1.0),
+            reserve=1.25,
+            tuning=self.tuning,
+        )
+        self.assertTrue(decision.reserve_limited)
+        self.assertLessEqual(decision.reserve_cost, 1.25 + 1e-8)
+        self.assertGreater(decision.time_scale, decision.requested_time_scale)
+
+    def test_ambiguity_weakens_assist_weight(self) -> None:
+        clear = evaluate_threat(
+            ThreatSignature(0.50, severity=0.9, confidence=0.9, ambiguity=0.0),
+            tuning=self.tuning,
+        )
+        ambiguous = evaluate_threat(
+            ThreatSignature(0.50, severity=0.9, confidence=0.9, ambiguity=1.0),
+            tuning=self.tuning,
+        )
+        self.assertLess(ambiguous.assist_weight, clear.assist_weight)
+
+    def test_success_estimate_is_seeded_and_bounded(self) -> None:
+        decision = evaluate_threat(
+            ThreatSignature(0.50, severity=1.0, confidence=1.0),
+            tuning=self.tuning,
+        )
+        first = estimate_success_rate(decision, samples=1_000, seed=19)
+        second = estimate_success_rate(decision, samples=1_000, seed=19)
+        self.assertEqual(first, second)
+        self.assertGreaterEqual(first, 0)
+        self.assertLessEqual(first, 1)
+
+    def test_invalid_inputs_are_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            ThreatSignature(-0.1, severity=1.0, confidence=1.0)
+        with self.assertRaises(ValueError):
+            ThreatSignature(0.1, severity=1.1, confidence=1.0)
+        with self.assertRaises(ValueError):
+            evaluate_threat(
+                ThreatSignature(0.1, severity=1.0, confidence=1.0),
+                reserve=-1,
+            )
+        with self.assertRaises(ValueError):
+            smoothstep(1.0, 1.0, 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- adds **Serpentine Sense / Aethercoil** as a second playable cognition mode in the existing SwiftUI game
- introduces four distinct sensing channels: Coil Instinct, Aura Sight, Aetherware Oracle, and Hex Echo
- models five systemic threat families across eight directions with separate orientation and response choices
- generates synchronized stereo cues and haptic feedback, with independent modality toggles
- calculates time dilation from lead time, choice budget, confidence, severity, ambiguity, and available Aethercoil reserve
- adds a standard-library Python simulator plus deterministic balance tests
- documents the Gorgon-native power identity, human-factors assumptions, architecture, accessibility contract, telemetry, and Unreal-port path
- adds generated-file ignores and explicit Combine import/project source wiring

## Why

The original danger-sense concept solved an important interaction problem, but the project needs its own mythology and mechanical grammar. This version centers distributed serpentine perception, aura reading, sorcery causality, cybernetic prediction, gaze, and player agency rather than reducing the idea to a renamed spider ability or a one-button QTE.

## Player and developer impact

Players can read a multimodal omen, locate its direction, choose a Gorgon response verb, and decide whether to act or let the omen pass. Designers can tune the same balance equations outside Xcode and catch impossible or over-assisted reaction windows in CI.

## Validation

- `python3 -m unittest discover -s simulation -p 'test_*.py'` — 10 tests pass
- `python3 -m compileall -q simulation` — passes
- all Swift sources parsed with the Tree-sitter Swift grammar — no syntax errors
- Xcode project references each new Swift source exactly once
- every proposed branch file was fetched back and matched against the validated local source

## Not yet validated

This workspace does not contain Xcode or the Swift compiler, so `xcodebuild`, iOS type-checking, simulator interaction, stereo positioning, and on-device haptic timing remain review checkpoints.

## Suggested review path

1. Read `docs/SERPENTINE_SENSE_RFC.md`.
2. Run the Python balance tests and sample matrix.
3. Open the iOS project in Xcode 15+ and select the **Serpentine** tab.
4. Calibrate cue latency and haptic/audio intensity on a physical iPhone.

This PR is intentionally draft-stage. Squash merge is recommended once the on-device checkpoint passes.